### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ruby Bindings for libQt6, providing access to the Qt framework.
 ## Requirements
 
 - Ruby 3.4+
-- Qt 6.9+
+- Qt 6.10+
 - Linux
 
 ## Installation


### PR DESCRIPTION
2.0.0 does not build with qt 6.9.3

qstylehints-rb.cpp:4:10: fatal error: 'QAccessibilityHints' file not found

QAccessibilityHints is found in qt 6.10.1
